### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -1,5 +1,8 @@
 name: Daily Number Update
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/ericsherrill-made4net/fancy_job/security/code-scanning/1](https://github.com/ericsherrill-made4net/fancy_job/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block that limits the `GITHUB_TOKEN` to the minimal scopes needed. Since the shown workflow only checks out code and runs a local Python script, and we have no evidence it needs to write to the repository or issues/PRs, the safest change is to set repository contents to read-only via `contents: read`. This should be applied at the workflow level (top-level) so it covers all jobs unless overridden.

Concretely, in `.github/workflows/CI-CD.yml`, add a top-level `permissions:` mapping directly under the `name:` (and before `on:`) to declare least-privilege defaults for the workflow. For this workflow, a minimal and appropriate block is:

```yaml
permissions:
  contents: read
```

No imports or additional methods are required, since this is GitHub Actions YAML configuration only. The rest of the workflow’s behavior remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
